### PR TITLE
Improve grammar and spelling in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,10 @@
-JRichtTextEditor
+JRichTextEditor
 ================
 
-A rich text editor for Swing - uses structured XML as format.
+A rich text editor for Swing – uses structured XML as its format.
 
 JRichTextEditor is a stable rich text editor for the Java Swing widget set. 
-It has a range of features, including clipboard integration, zooming, meta data, 
-XML format, styles, etc. Used in a production environment it is released under LGPL. 
+It has a range of features, including clipboard integration, zooming, metadata, 
+XML format, and styles. It is used in a production environment and released under the LGPL. 
 
-There is a demo application that demonstrates the capabilities in
-
-https://github.com/hoesterholt/JRichTextEditor/tree/master/src/net/oesterholt/demo/jxmlnote
-
+There is a demo application that demonstrates the capabilities in [src/net/oesterholt/demo/jxmlnote](https://github.com/hoesterholt/JRichTextEditor/tree/master/src/net/oesterholt/demo/jxmlnote).


### PR DESCRIPTION
Including fixing the name of the component in the heading
